### PR TITLE
Upgrade peer dependency to react 0.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "keywords": [
     "react",
     "reactjs",
-    "ellipsis"
+    "ellipsis",
+	"react-component"
   ],
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Ellipsify content",
   "author": "Juho Vepsalainen <bebraw@gmail.com>",
   "user": "bebraw",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "scripts": {
     "start": "node server.js",
     "test": "jest && npm run lint",
@@ -31,8 +31,8 @@
     "jsx-loader": "^0.12.2",
     "markdown-loader": "^0.1.2",
     "purecss": "^0.6.0",
-    "react": "^0.12.2",
-    "react-ghfork": "^0.2.2",
+    "react": "^0.13",
+    "react-ghfork": "^0.3.2",
     "react-hot-loader": "^1.2.3",
     "react-tools": "^0.13.1",
     "style-loader": "^0.9.0",
@@ -42,7 +42,7 @@
     "xtend": "^4.0.0"
   },
   "peerDependencies": {
-    "react": "^0.12.2"
+    "react": "^0.13"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've upgraded the dev and peer dependencies for react to ^0.13, as this is the current stable version. No other changes were required. The tests are still passing, and I've tried out the example in browser with no problems. Additionally, I tried using this component in my app after the change with no problem.

I also bumped the react-ellipsify minor version, although that's totally up to you. My thinking is that although no breaking changes (or in fact any changes) have been introduced to this library, the minor version bump on the react dependency justifies a minor version bump on this library.

Additionally, I added the react-component keyword to the package config, which will cause this package to show up here if this change is sent to npm: http://react-components.com/
